### PR TITLE
Make properties and classes anchorable on the web. :anchor:

### DIFF
--- a/templates/ontology.html
+++ b/templates/ontology.html
@@ -95,7 +95,7 @@
                         <thead class="table-primary">
                         <tr>
                             <div class="d-flex align-items-center">
-                                <th colspan="2">{{key}}</th>
+                                <th colspan="2" id={{ key.split(':')[1] }}>{{key}}</th>
                             </div>
                         </tr>
                         </thead>


### PR DESCRIPTION
## What does this do?

Makes so that when someone goes to an anchored URL over the web they get sent to the anchor and not the page it resides on.

For instance, if someone goes to https://ontology.lib.utk.edu/works#ImageWork they should see this:

<img width="1380" alt="Screen Shot 2022-12-13 at 3 07 40 PM" src="https://user-images.githubusercontent.com/2692416/207433763-29b24a89-3d54-4c2f-8155-3dc7ce08a0e2.png">



Unfortunately, right now they see this:

<img width="1380" alt="Screen Shot 2022-12-13 at 3 08 00 PM" src="https://user-images.githubusercontent.com/2692416/207433723-6e918426-f7e9-489b-9903-597ee5b1cbf4.png">


This fixes that.

## Should what you described be working right now?

No, only once it gets to the web, but it does work locally right now.

