### PR TITLE
Add "shareMetadata" property.

### DIFF
--- a/ontologies/works.ttl
+++ b/ontologies/works.ttl
@@ -54,6 +54,13 @@ utk:AudioWork a utk:WorkType ;
     there should only be one canvas with multiple annotations.
     """@en .
 
+ utk:shareMetadata a rdf:Property ;
+    rdfs:label "share metadata"@en ;
+    rdfs:comment "Indicates whether metadata should be shared or restricted (in OAI-PMH, etc.)."@en ;
+    rdfs:domain utk:WorkType ;
+    rdfs:range rdfs:Literal;
+    rdfs:isDefinedBy utk: .
+
 utk:Behavior a rdfs:Class ;
     rdfs:label "Behavior"@en ;
     rdfs:comment "A feature that the publisher of IIIF content would prefer the client to use when presenting the resource."@en ;


### PR DESCRIPTION
**Jira Issue**: [DPLA-248](https://jirautk.atlassian.net/browse/DPLA-248)

## What does this Pull Request do?

This PR adds a new property - utk:shareMetadata. This property is needed in the future to allow us to automatically determine if metadata (for a particular object or one of it's pages/parts etc.) should be shared openly. The particular use case that brought up this need was the desire to restrict blank pages in the Delaney Sketchbooks from being shared in OAI-PMH (but to still describe these sketchbooks on the page level and include the blank pages).

## How should this be tested?

Is the syntax and spacing correct? Does the comment need any further clarification?

## Interested parties

@markpbaggett
